### PR TITLE
FEAT: simplify implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ testConfig
 unit.html
 graphify-out/
 AGENTS.md
+.opencode/

--- a/README.md
+++ b/README.md
@@ -1,121 +1,157 @@
 # Ayotl
 
-Ayotl is a lightweight Go library for loading configuration into well-defined structs.
-It supports **config files** (JSON/YAML), **environment variable placeholders** within those files, and **pure environment-variable mode** when no config file is needed.
+Ayotl is a lightweight Go library for loading configuration.
+It supports **config files** (JSON / YAML / INI), **environment variable placeholders** within those files,
+and **environment-only mode** for when no config file is needed — without forcing you
+to implement any interface.
+
+```go
+import "github.com/beabys/ayotl"
+```
 
 ---
 
 ## Quick Start
 
 ```go
-import "github.com/beabys/ayotl"
-
-type Config struct {
-	Server ServerConfig `mapstructure:"server"`
-	Logger LoggerConfig `mapstructure:"logger"`
-}
-
+// 1. Define your config struct with mapstructure tags
 type ServerConfig struct {
 	Host string `mapstructure:"host"`
 	Port int    `mapstructure:"port"`
 }
-
-type LoggerConfig struct {
-	Level string `mapstructure:"level"`
+type Config struct {
+	Server ServerConfig `mapstructure:"server"`
 }
+//                                                 
+// 2. Create a new config, load from file, unmarshal
+cfg := config.New().WithEnv().LoadConfigs("config.json")
+cfg.Unmarshal(&myConfig)
 ```
+
+No struct methods to implement. No interface to satisfy.
+Just set fields on `config.Config` and call load.
+
+---
 
 ## Modes
 
-### 1. Config File Mode
+### 1. Config File Mode — JSON / YAML / INI
 
-Load values from a `.json`, `.yaml`, or `.yml` file:
+Load values from a `.json`, `.yaml`, `.yml`, or `.ini` file:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
+cfg := config.New().
+    WithEnv().
     LoadConfigs("config.json")
 ```
 
-### 2. Environment-Only Mode (no file)
-
-Call `LoadConfigs()` with **no arguments**.
-The library walks your struct's `mapstructure` tags and reads matching env vars directly from the OS environment — **no need to call `.WithEnv()`**:
-
-| Struct path             | Env var              |
-|------------------------|----------------------|
-| `server.host`          | `SERVER_HOST`        |
-| `server.port`          | `SERVER_PORT`        |
-| `logger.level`         | `LOGGER_LEVEL`       |
-
-```go
-os.Setenv("SERVER_HOST", "localhost")
-os.Setenv("SERVER_PORT", "8080")
-os.Setenv("LOGGER_LEVEL", "debug")
-
-config := config.New().
-    SetConfigImpl(&myConfig).
-    LoadConfigs()   // ← no files, no WithEnv needed
-```
-
-Env var values are automatically converted to the target field type (string, int, bool, etc.).
-
-### 3. File Mode with Optional Placeholder Substitution
-
-Config values can be literal or reference env vars with `${VAR_NAME}`.
-The `${...}` notation is **optional** — you can mix literal values and placeholders freely in the same file:
+Config files support **optional** `${PLACEHOLDER}` substitution.
+Use `WithEnv()` to load env vars for placeholder resolution:
 
 ```json
 {
     "stage": "${STAGE}",
     "app": {
         "host": "127.0.0.1",
-        "port": "${APPLICATION_PORT}"
+        "port": "${APP_PORT}"
     }
 }
 ```
 
-Here `host` is a hardcoded literal, while `stage` and `port` will be replaced from env vars.
+```go
+cfg := config.New().
+    WithEnv().
+    LoadConfigs("config.json")
+// stage = os.Getenv("STAGE"), app.port = os.Getenv("APP_PORT")
+```
 
-**`.WithEnv()` is only needed for this mode.** It loads environment variables into an internal map so `${PLACEHOLDER}` values can be resolved. By default it loads **all** environment variables:
+Restrict which env vars are available for substitution for security:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
-    WithEnv().                      // ← needed for ${...} substitution
+cfg := config.New().
+    WithEnv("STAGE", "APP_PORT").  // ← only these two
     LoadConfigs("config.json")
 ```
 
-For security, restrict which env vars are loaded by passing explicit names.
-Only those vars will be available for substitution:
+If a referenced placeholder is not set (or filtered out), it resolves to empty string.
+
+---
+
+### 2. Environment-Only Mode — no files
+
+Call `LoadConfigs()` with **no arguments**.
+Env vars are loaded into `ConfigMap` via an explicit alias:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
-    WithEnv("STAGE", "APPLICATION_PORT").   // ← only these two
-    LoadConfigs("config.json")
+cfg := config.New()
+cfg.EnvAlias = config.ConfigEnvAlias{
+    "SERVER_HOST": "server.host",
+    "SERVER_PORT": "server.port",
+}
+cfg.WithEnv().LoadConfigs()
+
+fmt.Println(cfg.MustString("server.host", ""))  // "localhost"
 ```
 
-If a referenced env var is not set (or not included in the filter), the placeholder resolves to an empty string.
+`EnvAlias` maps env var names to dot-notation config keys.
+Only env vars listed in the alias are placed into `ConfigMap`.
 
-> **Note:** `.WithEnv()` is **not** used in environment-only mode (mode 2) — that mode reads `os.Getenv` directly via struct reflection.
+> **Note:** `LoadConfigs()` calls `WithEnv()` internally if env vars
+> haven't been loaded yet, so you can omit the explicit `WithEnv()` call:
+>
+> ```go
+> cfg := config.New()
+> cfg.EnvAlias = config.ConfigEnvAlias{
+>     "SERVER_HOST": "server.host",
+> }
+> cfg.LoadConfigs()  // ← WithEnv called internally
+> ```
 
 ---
 
 ## Default Values
 
-Implement `SetDefaults()` on your struct to provide fallback values in dot-notation.
-Defaults are applied only when the key is not already set (from file or env):
+Set fallback values via the `Defaults` field.
+Defaults are applied **before** env alias overrides,
+so env vars always take precedence:
 
 ```go
-func (c *Config) SetDefaults() ConfigMap {
-    return ConfigMap{
-        "server.host":   "127.0.0.1",
-        "server.port":   "3000",
-        "logger.level":  "info",
-    }
+cfg := config.New()
+cfg.Defaults = config.ConfigMap{
+    "server.host":   "127.0.0.1",
+    "server.port":   3000,
+    "logger.level":  "info",
 }
+cfg.LoadConfigs()
 ```
+
+Defaults and env alias can be combined freely.
+Env vars that match an alias key override the default.
+Keys not set by env keep their default.
+
+---
+
+## Constructor: `NewWithParams`
+
+Batch-set `Defaults` and `EnvAlias` at construction time:
+
+```go
+cfg := config.NewWithParams(&config.Params{
+    Defaults: config.ConfigMap{
+        "server.port":  9090,
+        "logger.level": "info",
+    },
+    EnvAlias: config.ConfigEnvAlias{
+        "SERVER_HOST": "server.host",
+        "SERVER_PORT": "server.port",
+    },
+})
+cfg.WithEnv().LoadConfigs()
+```
+
+`NewWithParams` does not modify `ConfigMap` or `EnvConfigMap` —
+it only sets `Defaults` and `EnvAlias`. Loading still happens
+when you call `LoadConfigs()`.
 
 ---
 
@@ -124,56 +160,74 @@ func (c *Config) SetDefaults() ConfigMap {
 Lock the config after loading to prevent accidental mutations at runtime:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
-    LoadConfigs("config.json")
+cfg := config.New()
+cfg.Defaults = config.ConfigMap{"server.host": "original"}
+cfg.LoadConfigs()
 
-config.Immutable()
+cfg.Immutable()
 
-// Any mutation attempt becomes a no-op:
-config.Set("server.host", "will-not-stick")
-config.SetConfigMap(newMap)
-config.WithEnv("SOME_SECRET")
+// All mutations become no-ops:
+cfg.Set("server.host", "will-not-stick")
+cfg.SetConfigMap(newMap)
+cfg.WithEnv("SOME_SECRET")
 ```
 
-`Immutable()` can also be called **before** `LoadConfigs()` — loading still works, but all post-load writes are blocked:
+`Immutable()` can be called **before** `LoadConfigs()` —
+loading still works (env vars and defaults are applied),
+but all post-load writes are blocked:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
-    Immutable().          // ← called before loading
+cfg := config.New()
+cfg.EnvAlias = config.ConfigEnvAlias{
+    "SERVER_HOST": "server.host",
+}
+cfg.Immutable().
     LoadConfigs()         // ← still works
 
-config.Set("server.host", "blocked")  // ← no-op
+cfg.Set("server.host", "blocked")  // ← no-op
 ```
 
-`SetDefault()` is also blocked after `Immutable()`, since it delegates to `Set()`. Only `Get`, `Must*`, and `Unmarshal` remain available.
+After `Immutable()`, only `Get`, `Must*`, and `Unmarshal` remain available.
 
 ---
 
 ## Unmarshal
 
-After loading, unmarshal the resolved values into your struct:
+After loading, decode the resolved `ConfigMap` into your typed struct:
 
 ```go
-config := config.New().
-    SetConfigImpl(&myConfig).
-    LoadConfigs("config.json")
+type Config struct {
+    Server ServerConfig `mapstructure:"server"`
+}
+type ServerConfig struct {
+    Host string `mapstructure:"host"`
+    Port int    `mapstructure:"port"`
+}
 
-if err := config.Unmarshal(&myConfig); err != nil {
+var myConfig Config
+cfg := config.New().WithEnv().LoadConfigs("config.json")
+if err := cfg.Unmarshal(&myConfig); err != nil {
     log.Fatal(err)
 }
+fmt.Println(myConfig.Server.Host)
 ```
+
+All fields need `mapstructure` struct tags to be recognized.
+
+---
 
 ## Access values directly
 
 Use the `Must*` helpers to read values by dot-notation key:
 
 ```go
-host := config.MustString("server.host", "localhost")
-port := config.MustInt("server.port", 3000)
-debug := config.MustBool("server.debug", false)
+host  := cfg.MustString("server.host", "localhost")
+port  := cfg.MustInt("server.port", 3000)
+debug := cfg.MustBool("server.debug", false)
 ```
+
+`Must*` checks `EnvConfigMap` first (env vars loaded by `WithEnv`),
+then falls back to `ConfigMap`. If neither has the key, the default value is returned.
 
 ---
 

--- a/config.go
+++ b/config.go
@@ -3,13 +3,12 @@ package config
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/spf13/cast"
 )
 
-// New return  a New Config
+// New returns a new Config instance with empty ConfigMap and EnvConfigMap.
 func New() *Config {
 	c := &Config{}
 	//create a default ConfigMap
@@ -18,6 +17,17 @@ func New() *Config {
 	return c
 }
 
+// NewWithParams returns a new Config instance with provided defaults and env alias.
+func NewWithParams(params *Params) *Config {
+	c := &Config{}
+	c.ConfigMap = make(ConfigMap)
+	c.EnvConfigMap = make(ConfigMap)
+	c.Defaults = params.Defaults
+	c.EnvAlias = params.EnvAlias
+	return c
+}
+
+// SetConfigMap sets the entire ConfigMap. If the Config is immutable, this is a no-op.
 func (c *Config) SetConfigMap(cm ConfigMap) *Config {
 	if c.immutable {
 		return c
@@ -26,22 +36,24 @@ func (c *Config) SetConfigMap(cm ConfigMap) *Config {
 	return c
 }
 
-func (c *Config) SetConfigImpl(impl Configuration) *Config {
-	c.configImpl = impl
-	return c
-}
-
 // LoadConfig is a function to load the configurations in ConfigMap
+// from the provided config files, and merge with env variables if exist
+// If no config files provided, apply defaults + env alias overrides
+// This is a convenience method that calls LoadConfigs with the provided files.
 func (c *Config) LoadConfigs(configFiles ...string) (err error) {
-	// If no config files provided, load only from env vars using struct reflection
+	// If no config files provided, apply defaults + env alias overrides
 	if len(configFiles) == 0 {
-		// load env vars into ConfigMap using struct reflection first
-		c.loadEnvOnly()
-		// set defaults from configImpl for any keys not provided by env
-		if c.configImpl != nil {
-			for key, val := range c.configImpl.SetDefaults() {
-				if !c.isSet(key) {
-					c.set(key, val)
+		// Temporarily disable immutability to allow env var merging
+		immutable := c.immutable
+		c.immutable = false
+		defer func() { c.immutable = immutable }() // Restore immutability after merging
+		c.setDefaults()
+		c.WithEnv() // Load all env vars if not already loaded
+		if len(c.EnvAlias) > 0 {
+			// itterate over the alias and set the values from env variables into the config map
+			for envKey, dotKey := range c.EnvAlias {
+				if envVal, ok := c.EnvConfigMap[envKey]; ok {
+					c.Set(dotKey, envVal)
 				}
 			}
 		}
@@ -60,13 +72,7 @@ func (c *Config) LoadConfigs(configFiles ...string) (err error) {
 	}
 
 	// set default values from the implementation
-	if c.configImpl != nil {
-		for key, val := range c.configImpl.SetDefaults() {
-			if !c.isSet(key) {
-				c.set(key, val)
-			}
-		}
-	}
+	c.setDefaults()
 
 	// load the configs from file
 	if err := c.getLocalConfigs(configFiles...); err != nil {
@@ -80,15 +86,6 @@ func (c *Config) LoadConfigs(configFiles ...string) (err error) {
 
 	return nil
 
-}
-
-func (c *Config) getLocalConfigs(configFiles ...string) error {
-	for _, s := range configFiles {
-		if err := c.ConfigFileMerge(s); err != nil {
-			return fmt.Errorf("fail to load configs from file %s: %w", s, err)
-		}
-	}
-	return nil
 }
 
 // ConfigFileMerge read configs from file and merge the config into ConfigMap
@@ -114,12 +111,21 @@ func (c *Config) Get(k string) interface{} {
 	return GetValue(c.ConfigMap, strings.Split(k, "."))
 }
 
+func (c *Config) getLocalConfigs(configFiles ...string) error {
+	for _, s := range configFiles {
+		if err := c.ConfigFileMerge(s); err != nil {
+			return fmt.Errorf("fail to load configs from file %s: %w", s, err)
+		}
+	}
+	return nil
+}
+
 func (c *Config) getEnv(k string) interface{} {
 	return GetValue(c.EnvConfigMap, []string{k})
 }
 
 // set applies a value to ConfigMap bypassing the immutability guard.
-// Used internally by LoadConfigs and loadEnvOnly during the loading phase.
+// Used internally by LoadConfigs during the loading phase.
 func (c *Config) set(k string, v interface{}) {
 	SetValue(c.ConfigMap, strings.Split(k, "."), v)
 }
@@ -154,10 +160,14 @@ func (c *Config) isSetEnv(k string) bool {
 	return value != nil
 }
 
-func (c *Config) SetDefault(key string, val interface{}) {
-	// if key don't exist we add it
-	if !c.isSet(key) {
-		c.Set(key, val)
+func (c *Config) setDefaults() {
+	if len(c.Defaults) > 0 {
+		// 1. Apply defaults
+		for key, val := range c.Defaults {
+			if !c.isSet(key) {
+				c.Set(key, val)
+			}
+		}
 	}
 }
 
@@ -175,6 +185,7 @@ func (c *Config) WithEnv(envs ...string) *Config {
 			c.EnvConfigMap[env[0]] = env[1]
 		}
 	}
+	c.envLoaded = true
 	return c
 }
 
@@ -273,87 +284,4 @@ func (c *Config) MustBool(key string, must bool) bool {
 func (c *Config) mergeEnvVariables() {
 	mergeENV := MergeEnvVar(c.ConfigMap, c.EnvConfigMap)
 	c.ConfigMap = mergeENV
-}
-
-// loadEnvOnly populates ConfigMap from environment variables using the struct's
-// mapstructure tags as a schema. No file loading is performed.
-// Requires configImpl to be set via SetConfigImpl. Uses os.Getenv directly.
-func (c *Config) loadEnvOnly() {
-	if c.configImpl == nil {
-		return
-	}
-
-	t := reflect.TypeOf(c.configImpl)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	if t.Kind() != reflect.Struct {
-		return
-	}
-
-	c.walkStructForEnv(t, "")
-}
-
-// walkStructForEnv recursively walks a struct type and maps env vars to ConfigMap keys.
-func (c *Config) walkStructForEnv(t reflect.Type, prefix string) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-
-		// Skip unexported fields
-		if !field.IsExported() {
-			continue
-		}
-
-		// Get mapstructure tag
-		tag, ok := field.Tag.Lookup("mapstructure")
-		if !ok || tag == "" {
-			continue
-		}
-
-		// Build dot-notation key
-		dotKey := tag
-		if prefix != "" {
-			dotKey = prefix + "." + tag
-		}
-
-		// Build env var name: uppercase dot-notation joined with _
-		envKey := strings.ToUpper(strings.ReplaceAll(dotKey, ".", "_"))
-
-		ft := field.Type
-		// Dereference pointer types
-		if ft.Kind() == reflect.Ptr {
-			ft = ft.Elem()
-		}
-
-		// Recurse into nested structs
-		if ft.Kind() == reflect.Struct {
-			c.walkStructForEnv(ft, dotKey)
-			continue
-		}
-
-		// Leaf field - look up env var
-		envVal := os.Getenv(envKey)
-		if envVal == "" {
-			continue
-		}
-
-		// Convert based on field type using cast
-		var val interface{}
-		switch ft.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			val = cast.ToInt64(envVal)
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			val = cast.ToUint(envVal)
-		case reflect.Float32, reflect.Float64:
-			val = cast.ToFloat64(envVal)
-		case reflect.Bool:
-			val = cast.ToBool(envVal)
-		case reflect.String:
-			val = cast.ToString(envVal)
-		default:
-			val = cast.ToString(envVal)
-		}
-		c.set(dotKey, val)
-
-	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -12,52 +12,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockConfig struct {
-	App     MockApplicationConfig `mapstructure:"application"`
-	Logger  MockLoggerConfig      `mapstructure:"logger"`
-	Logger2 MockLoggerConfig      `mapstructure:"logger2"`
-}
-type MockApplicationConfig struct {
-	Port int `mapstructure:"port"`
-}
-type MockLoggerConfig struct {
-	LogOutput   string `mapstructure:"log_output_to"`
-	ErrorOutput string `mapstructure:"log_errors_to"`
-	Level       string `mapstructure:"log_level"`
-}
-
-// EnvOnlyConfig is used for testing env-only loading.
-type EnvOnlyConfig struct {
-	Server  EnvServerConfig  `mapstructure:"server"`
-	Logger  *EnvLoggerConfig `mapstructure:"logger"`
-	Timeout int              `mapstructure:"timeout"`
-}
-
-// EnvServerConfig holds server-related env-only config.
-type EnvServerConfig struct {
-	Host  string `mapstructure:"host"`
-	Port  int    `mapstructure:"port"`
-	Debug bool   `mapstructure:"debug"`
-}
-
-// EnvLoggerConfig holds logger-related env-only config.
-type EnvLoggerConfig struct {
-	Level string `mapstructure:"level"`
+// Structs for unmarshal testing — no interfaces needed, just mapstructure tags.
+type AppConfig struct {
+	Server struct {
+		Enabled bool `mapstructure:"enabled"`
+	} `mapstructure:"server"`
+	Second struct {
+		Config struct {
+			Enabled bool `mapstructure:"enabled"`
+		} `mapstructure:"config"`
+	} `mapstructure:"second"`
 }
 
 func TestConfig(t *testing.T) {
-
 	path := "./testConfig/"
 	defer os.RemoveAll(path)
+
 	t.Run("test new should return a new config", func(t *testing.T) {
-		mock := &MockConfig{}
-		configMap := make(ConfigMap)
-		envConfigMap := make(ConfigMap)
-		config := New().SetConfigImpl(mock).SetConfigMap(configMap).WithEnv()
-		want := &Config{ConfigMap: configMap, EnvConfigMap: envConfigMap, configImpl: mock}
-		want.WithEnv()
-		areEqual := assert.ObjectsAreEqual(config, want)
-		assert.True(t, areEqual)
+		config := New()
+		assert.NotNil(t, config.ConfigMap)
+		assert.NotNil(t, config.EnvConfigMap)
 	})
 
 	t.Run("test Error Loading configs path without CONFIG_FILE", func(t *testing.T) {
@@ -68,14 +42,13 @@ func TestConfig(t *testing.T) {
 
 	t.Run("test Error Loading configs file", func(t *testing.T) {
 		os.Unsetenv("CONFIG_FILE")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock)
+		config := New()
 		assert.ErrorContains(t, config.LoadConfigs("./../env.configuration.json"), "fail to load configs")
 	})
 
 	t.Run("Test Loading configs", func(t *testing.T) {
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		mock := &AppConfig{}
+		config := New().WithEnv()
 		data := `{"server": {"enabled": false},"second": {"config": {"enabled": false}}}`
 		testPath, err := createTestConfigFile(path, "/config.json", data)
 		assert.NoError(t, err)
@@ -84,25 +57,44 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("Test Loading configs with config placeholders", func(t *testing.T) {
-		mock := &MockConfig{}
+		mock := &AppConfig{}
 		data := `{"server": {"enabled": "${IS_CONFIG_FOR_TEST_ENABLED}"},"second": {"config": {"enabled": false}}}`
 		testPath, err := createTestConfigFile(path, "/config.json", data)
 		assert.NoError(t, err)
 		os.Setenv("IS_CONFIG_FOR_TEST_ENABLED", "true")
-		// c := New()
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		assert.NoError(t, config.LoadConfigs(testPath+"/config.json"))
 		assert.NoError(t, config.Unmarshal(mock))
 		os.Unsetenv("IS_CONFIG_FOR_TEST_ENABLED")
 	})
 
+	t.Run("Test Loading ini configs", func(t *testing.T) {
+		type ServerConfig struct {
+			Host string `mapstructure:"host"`
+			Port string `mapstructure:"port"`
+		}
+		type AppConfig struct {
+			Server ServerConfig `mapstructure:"server"`
+		}
+
+		data := "[server]\nhost = localhost\nport = 8080\n"
+		testPath, err := createTestConfigFile(path, "/config.ini", data)
+		assert.NoError(t, err)
+
+		mock := &AppConfig{}
+		config := New()
+		assert.NoError(t, config.LoadConfigs(testPath+"/config.ini"))
+		assert.NoError(t, config.Unmarshal(mock))
+		assert.Equal(t, "localhost", mock.Server.Host)
+		assert.Equal(t, "8080", mock.Server.Port)
+	})
+
 	t.Run("Test Loading configs with config placeholders and no Value", func(t *testing.T) {
-		mock := &MockConfig{}
+		mock := &AppConfig{}
 		data := `{"server": {"enabled": "${IS_CONFIG_FOR_TEST_ENABLED_SECOND}"},"second": {"config": {"enabled": false}}}`
 		testPath, err := createTestConfigFile(path, "/config.json", data)
 		assert.NoError(t, err)
-		// c := &Config{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		assert.NoError(t, config.LoadConfigs(testPath+"/config.json"))
 		assert.NoError(t, config.Unmarshal(mock))
 	})
@@ -110,9 +102,8 @@ func TestConfig(t *testing.T) {
 
 func TestMustFunctions(t *testing.T) {
 	t.Run("test MustBool", func(t *testing.T) {
-		mock := &MockConfig{}
 		os.Setenv("ANY", "false")
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := true
 		val := config.MustBool("ANY", required)
 		assert.False(t, val)
@@ -120,8 +111,7 @@ func TestMustFunctions(t *testing.T) {
 	})
 	t.Run("test MustBool exist", func(t *testing.T) {
 		os.Setenv("ANY", "true")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := true
 		val := config.MustBool("ANY", required)
 		assert.True(t, val)
@@ -129,8 +119,7 @@ func TestMustFunctions(t *testing.T) {
 	})
 	t.Run("test MustString", func(t *testing.T) {
 		os.Setenv("ANY", "required")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := "required"
 		val := config.MustString("ANY", required)
 		assert.Equal(t, val, required)
@@ -139,8 +128,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt", func(t *testing.T) {
 		os.Setenv("ANY", "0")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := 0
 		val := config.MustInt("ANY", required)
 		assert.Equal(t, val, required)
@@ -149,8 +137,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt32", func(t *testing.T) {
 		os.Setenv("ANY", "0")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		integer := 0
 		required := int32(integer)
 		val := config.MustInt32("ANY", required)
@@ -160,8 +147,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt64", func(t *testing.T) {
 		os.Setenv("ANY", "0")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		integer := 0
 		required := int64(integer)
 		val := config.MustInt64("ANY", required)
@@ -171,8 +157,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustString with variable", func(t *testing.T) {
 		os.Setenv("ANY", "required")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := "required"
 		val := config.MustString("ANY", required)
 		assert.Equal(t, val, required)
@@ -181,8 +166,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt with variable", func(t *testing.T) {
 		os.Setenv("ANY", "10")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		required := 10
 		val := config.MustInt("ANY", required)
 		assert.Equal(t, val, required)
@@ -191,8 +175,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt32 with variable", func(t *testing.T) {
 		os.Setenv("ANY", "10")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		integer := 10
 		required := int32(integer)
 		val := config.MustInt32("ANY", required)
@@ -202,8 +185,7 @@ func TestMustFunctions(t *testing.T) {
 
 	t.Run("test MustInt64 with variable", func(t *testing.T) {
 		os.Setenv("ANY", "10")
-		mock := &MockConfig{}
-		config := New().SetConfigImpl(mock).WithEnv()
+		config := New().WithEnv()
 		integer := 10
 		required := int64(integer)
 		val := config.MustInt64("ANY", required)
@@ -213,15 +195,39 @@ func TestMustFunctions(t *testing.T) {
 }
 
 func TestLoadEnvOnly(t *testing.T) {
-	// Set env vars matching the struct's mapstructure tags
 	t.Setenv("SERVER_HOST", "localhost")
 	t.Setenv("SERVER_PORT", "8080")
 	t.Setenv("SERVER_DEBUG", "true")
 	t.Setenv("LOGGER_LEVEL", "debug")
 	t.Setenv("TIMEOUT", "30")
 
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
+	type ServerConfig struct {
+		Host  string `mapstructure:"host"`
+		Port  int    `mapstructure:"port"`
+		Debug bool   `mapstructure:"debug"`
+	}
+	type LoggerConfig struct {
+		Level string `mapstructure:"level"`
+	}
+	type AppConfig struct {
+		Server  ServerConfig  `mapstructure:"server"`
+		Logger  *LoggerConfig `mapstructure:"logger"`
+		Timeout int           `mapstructure:"timeout"`
+	}
+
+	config := New()
+	config.Defaults = ConfigMap{
+		"server.port":   9090,
+		"logger.level":  "info",
+		"timeout":       60,
+	}
+	config.EnvAlias = ConfigEnvAlias{
+		"SERVER_HOST":   "server.host",
+		"SERVER_PORT":   "server.port",
+		"SERVER_DEBUG":  "server.debug",
+		"LOGGER_LEVEL":  "logger.level",
+		"TIMEOUT":       "timeout",
+	}
 	err := config.LoadConfigs()
 	assert.NoError(t, err)
 
@@ -233,6 +239,7 @@ func TestLoadEnvOnly(t *testing.T) {
 	assert.Equal(t, 30, config.MustInt("timeout", 0))
 
 	// Verify values via Unmarshal
+	mock := &AppConfig{}
 	err = config.Unmarshal(mock)
 	assert.NoError(t, err)
 	assert.Equal(t, "localhost", mock.Server.Host)
@@ -247,8 +254,19 @@ func TestLoadEnvOnlyWithDefaults(t *testing.T) {
 	// Set only one env var
 	t.Setenv("SERVER_HOST", "example.com")
 
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
+	config := New()
+	config.Defaults = ConfigMap{
+		"server.port":   9090,
+		"logger.level":  "info",
+		"timeout":       60,
+	}
+	config.EnvAlias = ConfigEnvAlias{
+		"SERVER_HOST":   "server.host",
+		"SERVER_PORT":   "server.port",
+		"SERVER_DEBUG":  "server.debug",
+		"LOGGER_LEVEL":  "logger.level",
+		"TIMEOUT":       "timeout",
+	}
 	err := config.LoadConfigs()
 	assert.NoError(t, err)
 
@@ -261,6 +279,16 @@ func TestLoadEnvOnlyWithDefaults(t *testing.T) {
 	assert.Equal(t, 60, config.MustInt("timeout", 0))
 }
 
+func TestLoadEnvOnlyWithoutAlias(t *testing.T) {
+	// No Defaults, no EnvAlias — just env vars in EnvConfigMap
+	t.Setenv("SOME_VAR", "value")
+	config := New()
+	err := config.LoadConfigs()
+	assert.NoError(t, err)
+	// No panic, ConfigMap empty (no alias to map anything)
+	assert.Nil(t, config.Get("SOME_VAR"))
+}
+
 func TestLoadEnvOnlyWithoutImpl(t *testing.T) {
 	config := New()
 	// Should not panic when no configImpl is set
@@ -268,11 +296,38 @@ func TestLoadEnvOnlyWithoutImpl(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNewWithParams(t *testing.T) {
+	params := &Params{
+		Defaults: ConfigMap{
+			"server.port": 9090,
+		},
+		EnvAlias: ConfigEnvAlias{
+			"SERVER_HOST": "server.host",
+		},
+	}
+	cfg := NewWithParams(params)
+	assert.Equal(t, params.Defaults, cfg.Defaults)
+	assert.Equal(t, params.EnvAlias, cfg.EnvAlias)
+	// Maps are initialized
+	assert.NotNil(t, cfg.ConfigMap)
+	assert.NotNil(t, cfg.EnvConfigMap)
+
+	// Load + verify
+	t.Setenv("SERVER_HOST", "example.com")
+	cfg.WithEnv().LoadConfigs()
+	assert.Equal(t, "example.com", cfg.MustString("server.host", ""))
+	assert.Equal(t, 9090, cfg.MustInt("server.port", 0))
+}
+
 func TestImmutableBlocksSet(t *testing.T) {
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
-	err := config.LoadConfigs()
-	assert.NoError(t, err)
+	config := New()
+	config.Defaults = ConfigMap{
+		"server.host": "original",
+	}
+	config.EnvAlias = ConfigEnvAlias{
+		"SERVER_HOST": "server.host",
+	}
+	_ = config.LoadConfigs()
 
 	// Sanity check: Set works before Immutable
 	config.Set("server.host", "should-work")
@@ -290,8 +345,12 @@ func TestImmutableAllowsLoadConfigs(t *testing.T) {
 	t.Setenv("SERVER_HOST", "immutable-load-test")
 	t.Setenv("SERVER_PORT", "3000")
 
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock).Immutable()
+	config := New()
+	config.EnvAlias = ConfigEnvAlias{
+		"SERVER_HOST": "server.host",
+		"SERVER_PORT": "server.port",
+	}
+	config.Immutable()
 
 	// LoadConfigs must still work even after Immutable
 	err := config.LoadConfigs()
@@ -307,8 +366,7 @@ func TestImmutableAllowsLoadConfigs(t *testing.T) {
 }
 
 func TestImmutableBlocksSetConfigMap(t *testing.T) {
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
+	config := New()
 	_ = config.LoadConfigs()
 	config.Immutable()
 
@@ -316,16 +374,25 @@ func TestImmutableBlocksSetConfigMap(t *testing.T) {
 	assert.NotEqual(t, "nope", config.MustString("server.host", ""))
 }
 
-func TestImmutableBlocksWithEnv(t *testing.T) {
+func TestImmutableBlocksPublicWithEnv(t *testing.T) {
+	t.Setenv("SERVER_HOST", "immutable-test")
 	t.Setenv("SHOULD_NOT_LOAD", "secret")
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
+
+	config := New()
+	config.EnvAlias = ConfigEnvAlias{
+		"SERVER_HOST": "server.host",
+	}
 	_ = config.LoadConfigs()
 	config.Immutable()
 
-	// WithEnv should be a no-op when immutable
+	// WithEnv is a no-op after Immutable
 	config.WithEnv()
-	assert.Equal(t, "", config.MustString("SHOULD_NOT_LOAD", ""))
+
+	// Env vars NOT in the alias should NOT be in ConfigMap
+	assert.Nil(t, config.Get("SHOULD_NOT_LOAD"))
+
+	// Env vars that ARE in the alias should still be accessible
+	assert.NotEmpty(t, config.MustString("server.host", ""))
 }
 
 func TestImmutableBlocksConfigFileMerge(t *testing.T) {
@@ -333,8 +400,7 @@ func TestImmutableBlocksConfigFileMerge(t *testing.T) {
 	path := filepath.Join(dir, "test.json")
 	assert.NoError(t, os.WriteFile(path, []byte(`{"server":{"host":"from-file"}}`), 0644))
 
-	mock := &EnvOnlyConfig{}
-	config := New().SetConfigImpl(mock)
+	config := New()
 	_ = config.LoadConfigs()
 	config.Immutable()
 
@@ -342,22 +408,6 @@ func TestImmutableBlocksConfigFileMerge(t *testing.T) {
 	err := config.ConfigFileMerge(path)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "from-file", config.MustString("server.host", ""))
-}
-
-func (ec *EnvOnlyConfig) SetDefaults() ConfigMap {
-	return ConfigMap{
-		"server.port":   9090,
-		"logger.level":  "info",
-		"timeout":       60,
-	}
-}
-
-func (mc *MockConfig) SetDefaults() ConfigMap {
-	defaults := make(ConfigMap)
-	defaults["this.is.a.very.nested.config"] = true
-	defaults["this.is.a.very.nested.config.with"] = "one"
-	defaults["this.is.a.very.nested.config.with.second"] = int(2)
-	return defaults
 }
 
 func createTestConfigFile(path, filename, data string) (string, error) {

--- a/file.go
+++ b/file.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,6 +26,8 @@ func ReadFile(file string) (ConfigMap, error) {
 		err = jsonDecode(content, &dataMap)
 	case ext == "yaml" || ext == "yml":
 		err = yamlDecode(content, &dataMap)
+	case ext == "ini":
+		err = iniDecode(content, &dataMap)
 	default:
 		err = fmt.Errorf("invalid extension type: %s", ext)
 	}
@@ -40,6 +43,26 @@ func jsonDecode(j []byte, d *ConfigMap) error {
 
 func yamlDecode(j []byte, d *ConfigMap) error {
 	return yaml.Unmarshal(j, d)
+}
+
+func iniDecode(j []byte, d *ConfigMap) error {
+	cfg, err := ini.Load(j)
+	if err != nil {
+		return err
+	}
+	*d = make(ConfigMap)
+	for _, section := range cfg.Sections() {
+		name := section.Name()
+		if name == "DEFAULT" {
+			continue
+		}
+		sectionMap := make(ConfigMap)
+		for _, key := range section.Keys() {
+			sectionMap[key.Name()] = key.String()
+		}
+		(*d)[name] = sectionMap
+	}
+	return nil
 }
 
 func getFileExt(s string) (ext string) {

--- a/file_test.go
+++ b/file_test.go
@@ -64,6 +64,52 @@ func TestReadFileYAMLAndYML(t *testing.T) {
 	}
 }
 
+func TestReadFileINI(t *testing.T) {
+	dir := t.TempDir()
+	iniContent := `[server]
+host = localhost
+port = 8080
+
+[logger]
+level = debug
+`
+	path := writeTempFile(t, dir, "test.ini", iniContent)
+
+	m, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned unexpected error: %v", err)
+	}
+
+	server, ok := m["server"].(ConfigMap)
+	if !ok {
+		t.Fatalf("expected server to be ConfigMap, got %#v", m["server"])
+	}
+	if v, _ := server["host"].(string); v != "localhost" {
+		t.Fatalf("expected server.host = localhost, got %#v", server["host"])
+	}
+	if v, _ := server["port"].(string); v != "8080" {
+		t.Fatalf("expected server.port = 8080, got %#v", server["port"])
+	}
+
+	logger, ok := m["logger"].(ConfigMap)
+	if !ok {
+		t.Fatalf("expected logger to be ConfigMap, got %#v", m["logger"])
+	}
+	if v, _ := logger["level"].(string); v != "debug" {
+		t.Fatalf("expected logger.level = debug, got %#v", logger["level"])
+	}
+}
+
+func TestReadFileINIMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "bad.ini", "[server\nhost = localhost")
+
+	_, err := ReadFile(path)
+	if err == nil {
+		t.Fatalf("expected ini decode error, got nil")
+	}
+}
+
 func TestReadFileInvalidExtension(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "test.txt", "a: b")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cast v1.10.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/ini.v1 v1.67.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -16,9 +17,19 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.2 h1:JtOSMb9OuaCZKr7h5D/h6iii14sK0hLbplTc6frx4Ss=
+gopkg.in/ini.v1 v1.67.2/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/maps.go
+++ b/maps.go
@@ -156,10 +156,11 @@ func SetValue(m map[string]interface{}, keysToFind []string, value interface{}) 
 	default:
 		// if still has more keys, override the current value with
 		// with a new nested map[string]interface{}
+		val = value
 		if len(next) > 0 {
 			val = SetValue(make(map[string]interface{}), next, value)
 		}
-		// create the new key in the map
+		// create or update the key in the map
 		m[keyVal] = val
 
 	}

--- a/types.go
+++ b/types.go
@@ -1,14 +1,18 @@
 package config
 
 type ConfigMap map[string]interface{}
-
-type Configuration interface {
-	SetDefaults() ConfigMap
-}
+type ConfigEnvAlias map[string]string
 
 type Config struct {
 	ConfigMap    ConfigMap
 	EnvConfigMap ConfigMap
-	configImpl   Configuration
+	Defaults     ConfigMap
+	EnvAlias     ConfigEnvAlias
 	immutable    bool
+	envLoaded    bool
+}
+
+type Params struct {
+	Defaults ConfigMap
+	EnvAlias ConfigEnvAlias
 }


### PR DESCRIPTION
- Remove the interface of methods to simplify implementation.
- Add env alias to map environment variables into dot notation keys.
- Avoid loading more than one time the environment variables.
- edit documentation